### PR TITLE
Fix stream cmd encode

### DIFF
--- a/adb/adb_protocol.py
+++ b/adb/adb_protocol.py
@@ -432,7 +432,7 @@ class AdbMessage(object):
           The responses from the service.
         """
         if not isinstance(command, bytes):
-            command = command.encode('utf8')
+            command = command.encode('utf8', 'ignore')
         connection = cls.Open(
             usb, destination=b'%s:%s' % (service, command),
             timeout_ms=timeout_ms)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ except ImportError:
 setup(
     name = 'adb',
     packages = ['adb'],
-    version = '1.3.0',
+    version = '1.3.0_o1',
     author = 'Fahrzin Hemmati',
     author_email = 'fahhem@gmail.com',
     maintainer = 'Fahrzin Hemmati',


### PR DESCRIPTION
Not sure why this error did not occur when doing regular testing before but this is a very similar fix to a previous commit: 
https://github.com/OnBeep/python-adb/commit/4abf9433b3c1d5530c458d6b30bc9b23b36669d1

Due to this being a change on a python module to get these updates use `pip` command to upgrade version.  